### PR TITLE
Persistent close button, scoped progress, and splash logging

### DIFF
--- a/Tharga.Wpf/Features/ApplicationUpdate/ApplicationUpdateStateService.cs
+++ b/Tharga.Wpf/Features/ApplicationUpdate/ApplicationUpdateStateService.cs
@@ -23,12 +23,22 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
     protected readonly ThargaWpfOptions _options;
     protected readonly string _environmentName;
 
-    private ISplash _splash;
+    /// <summary>
+    /// Current splash window. Visible to subclasses so they can show/hide progress and the
+    /// close button at the precise moment they know an update is actually starting/finishing.
+    /// </summary>
+    protected ISplash _splash;
     private string _applicationLocation;
     private string _applicationLocationSource;
     private string _logFileName;
     private bool _checkingForUpdate;
     private bool _isUpdating;
+    /// <summary>
+    /// True when the splash was opened with an explicit user-visible close button
+    /// (e.g. from an About menu). In that case we never hide the close button while
+    /// the splash is open, even during an update.
+    /// </summary>
+    protected bool _persistentCloseButton;
 
     internal static readonly List<string> UpdateLog = new();
 
@@ -125,13 +135,17 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
 
     private void CloseSplash()
     {
+        _logger.LogInformation("CloseSplash (persistentCloseButton was {Persistent}).", _persistentCloseButton);
         _splash?.Close();
         _splash = null;
+        _persistentCloseButton = false;
         UpdateInfoEvent -= ApplicationUpdateStateService_UpdateInfoEvent;
     }
 
     private Task ShowSplashAsync(bool firstRun, string entryMessage, bool showCloseButton)
     {
+        _logger.LogInformation("ShowSplashAsync(firstRun={FirstRun}, showCloseButton={ShowCloseButton}, persistentCloseButton={Persistent}, splashExists={SplashExists}).", firstRun, showCloseButton, _persistentCloseButton, _splash != null);
+
         if (_splash == null)
         {
             Uri.TryCreate(_applicationLocation, UriKind.Absolute, out var applicationLocation);
@@ -148,16 +162,31 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
                 FullName = _options.ApplicationFullName ?? $"{_options.CompanyName} {_options.ApplicationShortName}".Trim(),
                 ClientLocation = applicationLocation,
                 ClientSourceLocation = applicationSourceLocation,
-                SplashClosed = e => { SplashCompleteEvent?.Invoke(this, new SplashCompleteEventArgs(e, true)); },
+                SplashClosed = e =>
+                {
+                    _persistentCloseButton = false;
+                    SplashCompleteEvent?.Invoke(this, new SplashCompleteEventArgs(e, true));
+                },
                 ImagePath = SplashImageLibrary.TealTransparent
             };
-            _splash = Application.Current.Dispatcher.Invoke(() =>
-                _options.SplashCreator?.Invoke(splashData) ?? new Splash(splashData));
+            var app = Application.Current;
+            var dispatcher = app?.Dispatcher;
+            if (dispatcher == null)
+            {
+                _logger.LogError("Cannot create splash - Application.Current.Dispatcher is null. Calling thread ApartmentState={ApartmentState}.", Thread.CurrentThread.GetApartmentState());
+                return Task.CompletedTask;
+            }
+
+            _splash = dispatcher.Invoke(() =>
+            {
+                _logger.LogInformation("Creating splash on thread ApartmentState={ApartmentState}, IsDispatcherThread={IsDispatcherThread}.", Thread.CurrentThread.GetApartmentState(), dispatcher.CheckAccess());
+                return _options.SplashCreator?.Invoke(splashData) ?? new Splash(splashData);
+            });
             UpdateInfoEvent += ApplicationUpdateStateService_UpdateInfoEvent;
         }
 
         _splash.HideProgress();
-        if (showCloseButton)
+        if (showCloseButton || _persistentCloseButton)
             _splash.ShowCloseButton();
         else
             _splash.HideCloseButton();
@@ -180,7 +209,7 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
             if (_checkingForUpdate)
             {
                 AddLogString($"Ignore {nameof(UpdateClientApplication)} since it is already running. (source: {source})");
-                //UpdateInfoEvent?.Invoke(this, new UpdateInfoEventArgs($"Ignore update from {source} since it is already running."));
+                _logger.LogInformation("UpdateClientApplication ignored - already running. source={Source}", source);
                 return;
             }
 
@@ -188,6 +217,7 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
             _checkingForUpdate = true;
 
             AddLogString($"--- Start {nameof(UpdateClientApplication)} (source: {source}) ---");
+            _logger.LogInformation("UpdateClientApplication start. source={Source}, persistentCloseButton={Persistent}", source, _persistentCloseButton);
 
             UpdateInfoEvent?.Invoke(this, new UpdateInfoEventArgs("Looking for update."));
 
@@ -195,6 +225,7 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
             {
                 var message = $"{_options.ApplicationShortName} is running in debug mode.";
                 UpdateInfoEvent?.Invoke(this, new UpdateInfoEventArgs(message));
+                _logger.LogInformation("UpdateClientApplication skipped - debugger attached.");
                 return;
             }
 
@@ -212,12 +243,15 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
             {
                 AddLogString($"locationSource: {result.ApplicationLocationSource}");
                 AddLogString($"clientLocation: {clientLocation}");
+                _logger.LogInformation("UpdateClientApplication invoking UpdateAsync. clientLocation={ClientLocation}", clientLocation);
 
                 _isUpdating = true;
-                await ShowSplashWithRetryAsync(false);
-                _splash?.HideCloseButton();
-                _splash?.ShowProgress();
+                await ShowSplashWithRetryAsync(false, null, _persistentCloseButton);
 
+                // The close button + progress visibility during the update is the subclass's
+                // responsibility (it knows whether an update is actually being downloaded vs
+                // "already up to date"). The persistent close button is honoured by
+                // ShowSplashAsync above, so the subclass should NOT hide it when persistent.
                 await UpdateAsync(clientLocation);
             }
         }
@@ -251,6 +285,9 @@ internal abstract class ApplicationUpdateStateServiceBase : IApplicationUpdateSt
 
     public async Task ShowSplashAsync(bool checkForUpdates, bool showCloseButton, bool checkForLicense)
     {
+        _logger.LogInformation("ShowSplashAsync(checkForUpdates={CheckForUpdates}, showCloseButton={ShowCloseButton}, checkForLicense={CheckForLicense}).", checkForUpdates, showCloseButton, checkForLicense);
+        if (showCloseButton) _persistentCloseButton = true;
+
         await ShowSplashWithRetryAsync(false, null, showCloseButton);
         if (checkForUpdates) await CheckForUpdateAsync($"{nameof(ShowSplashAsync)}");
         if (checkForLicense) await CheckForLicenseAsync($"{nameof(ShowSplashAsync)}");

--- a/Tharga.Wpf/Features/ApplicationUpdate/Splash.xaml
+++ b/Tharga.Wpf/Features/ApplicationUpdate/Splash.xaml
@@ -23,7 +23,7 @@
         </ListBox>
         <TextBlock x:Name="Environment" FontSize="12" Margin="10,34,280,195" d:Text="Environment" />
         <TextBlock x:Name="Version" FontSize="12" Margin="10,48,280,180" d:Text="1.2.3.4" />
-        <TextBlock x:Name="ExeLocation" FontSize="12" Margin="10,62,280,166" d:Text="[exe location]" />
+        <TextBlock x:Name="ExeLocation" FontSize="12" Margin="10,62,280,166" d:Text="[exe location]" Visibility="Collapsed" />
         <TextBox x:Name="ErrorMessage" FontSize="10" Margin="5,155,5,5" d:Text="Error message" d:Visibility="Visible" Visibility="Collapsed" IsReadOnly="true" Background="AliceBlue" />
         <TextBlock x:Name="Client" Margin="10,225,10,10"><Hyperlink x:Name="ClientLocation" RequestNavigate="Client_RequestNavigate">Client</Hyperlink></TextBlock>
         <TextBlock x:Name="ClientSource" Margin="100,225,10,10"><Hyperlink x:Name="ClientSourceLocation"  RequestNavigate="ClientSource_RequestNavigate">Client Source</Hyperlink></TextBlock>

--- a/Tharga.Wpf/Features/ApplicationUpdate/Splash.xaml.cs
+++ b/Tharga.Wpf/Features/ApplicationUpdate/Splash.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using System.Text;
 using System.Windows;
 using System.Windows.Input;
@@ -14,6 +15,7 @@ public partial class Splash : ISplash
 {
     private readonly Action<CloseMethod> _splashClosed;
     private CloseMethod _closeMethod = CloseMethod.Automatically;
+    private readonly ILogger<Splash> _logger;
 
     private void DispatchIfRequired(Action action)
     {
@@ -36,6 +38,8 @@ public partial class Splash : ISplash
     /// <param name="splashData">The data to display on the splash screen.</param>
     public Splash(SplashData splashData)
     {
+        _logger = ApplicationBase.GetService<ILogger<Splash>>();
+
         if (splashData.MainWindow.Visibility == Visibility.Visible)
         {
             Owner = splashData.MainWindow;
@@ -93,30 +97,35 @@ public partial class Splash : ISplash
     /// <inheritdoc />
     public void UpdateInfo(string message)
     {
+        _logger.LogInformation(message);
         DispatchIfRequired(() => Messages.Items.Add(message));
     }
 
     /// <inheritdoc />
     void ISplash.Show()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(Show));
         DispatchIfRequired(Show);
     }
 
     /// <inheritdoc />
     void ISplash.Hide()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(Hide));
         DispatchIfRequired(Hide);
     }
 
     /// <inheritdoc />
     void ISplash.Close()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(Close));
         DispatchIfRequired(Close);
     }
 
     /// <inheritdoc />
     public void SetErrorMessage(string message)
     {
+        _logger.LogError(message);
         DispatchIfRequired(() =>
         {
             ErrorMessage.Text = message;
@@ -127,24 +136,28 @@ public partial class Splash : ISplash
     /// <inheritdoc />
     public void ShowCloseButton()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(ShowCloseButton));
         DispatchIfRequired(() => CloseButton.Visibility = Visibility.Visible);
     }
 
     /// <inheritdoc />
     public void HideCloseButton()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(HideCloseButton));
         DispatchIfRequired(() => CloseButton.Visibility = Visibility.Collapsed);
     }
 
     /// <inheritdoc />
     public void ShowProgress()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(ShowProgress));
         DispatchIfRequired(() => UpdateProgressBar.Visibility = Visibility.Visible);
     }
 
     /// <inheritdoc />
     public void HideProgress()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(HideProgress));
         DispatchIfRequired(() => UpdateProgressBar.Visibility = Visibility.Collapsed);
     }
 
@@ -154,6 +167,7 @@ public partial class Splash : ISplash
     /// <inheritdoc />
     public void ClearMessages()
     {
+        _logger.LogInformation("Splash window action {action}.", nameof(ClearMessages));
         DispatchIfRequired(() =>
         {
             Messages.Items.Clear();
@@ -169,12 +183,14 @@ public partial class Splash : ISplash
 
     private void Client_RequestNavigate(object sender, RequestNavigateEventArgs e)
     {
+        _logger.LogInformation("{action} Start process /c start {uri}/RELEASES", nameof(Client_RequestNavigate), e.Uri.AbsoluteUri);
         Process.Start(new ProcessStartInfo("cmd", $"/c start {e.Uri.AbsoluteUri}/RELEASES") { CreateNoWindow = true });
         e.Handled = true;
     }
 
     private void ClientSource_RequestNavigate(object sender, RequestNavigateEventArgs e)
     {
+        _logger.LogInformation("{action} Start process /c start {uri}", nameof(ClientSource_RequestNavigate), e.Uri.AbsoluteUri);
         Process.Start(new ProcessStartInfo("cmd", $"/c start {e.Uri.AbsoluteUri}") { CreateNoWindow = true });
         e.Handled = true;
     }

--- a/Tharga.Wpf/Features/ApplicationUpdate/SquirrelApplicationUpdateStateService.cs
+++ b/Tharga.Wpf/Features/ApplicationUpdate/SquirrelApplicationUpdateStateService.cs
@@ -25,10 +25,13 @@ internal class SquirrelApplicationUpdateStateService : ApplicationUpdateStateSer
 
     protected override async Task UpdateAsync(string clientLocation)
     {
+        _logger.LogInformation("Squirrel UpdateAsync start. clientLocation={ClientLocation}", clientLocation);
+
         using var mgr = new UpdateManager(clientLocation);
         if (!mgr.IsInstalledApp)
         {
             var message = $"{_options.ApplicationShortName} is not installed.";
+            _logger.LogInformation("Squirrel UpdateAsync: {Message}", message);
             OnUpdateInfoEvent(this, message);
             return;
         }
@@ -36,22 +39,44 @@ internal class SquirrelApplicationUpdateStateService : ApplicationUpdateStateSer
         var updateInfo = await mgr.CheckForUpdate();
         if (updateInfo.CurrentlyInstalledVersion.Version == updateInfo.FutureReleaseEntry.Version)
         {
+            _logger.LogInformation("Squirrel UpdateAsync: already up to date ({Version}).", updateInfo.CurrentlyInstalledVersion.Version);
             OnUpdateInfoEvent(this, "Already up to date.");
+            // Make sure no progress bar is shown when there is nothing to download.
+            _splash?.HideProgress();
             return;
         }
 
-        await ShowSplashWithRetryAsync(false);
+        _logger.LogInformation("Squirrel UpdateAsync: update available {From} -> {To}.", updateInfo.CurrentlyInstalledVersion.Version, updateInfo.FutureReleaseEntry.Version);
+
+        await ShowSplashWithRetryAsync(false, null, _persistentCloseButton);
+
+        // Now we know there is a real download about to happen — show the progress bar.
+        _splash?.ShowProgress();
+        if (!_persistentCloseButton)
+        {
+            // During an actual update, hide the close button so the user can't kill it
+            // mid-download. If the splash was opened from the About menu (persistent),
+            // leave the close button visible per the user's intent.
+            _splash?.HideCloseButton();
+        }
 
         OnUpdateInfoEvent(this, $"Updating to latest version, {updateInfo.FutureReleaseEntry.Version}.");
 
-        var newVersion = await mgr.UpdateApp();
-        if (newVersion != null)
+        try
         {
-            await _tabNavigationStateService.CloseAllTabsAsync(true);
+            var newVersion = await mgr.UpdateApp();
+            if (newVersion != null)
+            {
+                await _tabNavigationStateService.CloseAllTabsAsync(true);
 
-            OnUpdateInfoEvent(this, "Restarting.");
-            ApplicationBase.ReleaseSingleInstanceLock();
-            UpdateManager.RestartApp();
+                OnUpdateInfoEvent(this, "Restarting.");
+                ApplicationBase.ReleaseSingleInstanceLock();
+                UpdateManager.RestartApp();
+            }
+        }
+        finally
+        {
+            _splash?.HideProgress();
         }
     }
 

--- a/Tharga.Wpf/Features/ApplicationUpdate/VelopackApplicationUpdateStateService.cs
+++ b/Tharga.Wpf/Features/ApplicationUpdate/VelopackApplicationUpdateStateService.cs
@@ -9,17 +9,23 @@ namespace Tharga.Wpf.ApplicationUpdate;
 
 internal class VelopackApplicationUpdateStateService : ApplicationUpdateStateServiceBase
 {
+    private readonly ILogger<VelopackApplicationUpdateStateService> _logger;
+
     public VelopackApplicationUpdateStateService(IConfiguration configuration, ILoggerFactory loggerFactory, ILicenseClient licenseClient, IApplicationDownloadService applicationDownloadService, ITabNavigationStateService tabNavigationStateService, ThargaWpfOptions options, Window mainWindow)
         : base(configuration, loggerFactory, licenseClient, applicationDownloadService, tabNavigationStateService, options, mainWindow)
     {
+        _logger = loggerFactory.CreateLogger<VelopackApplicationUpdateStateService>();
     }
 
     protected override async Task UpdateAsync(string clientLocation)
     {
+        _logger.LogInformation("Velopack UpdateAsync start. clientLocation={ClientLocation}", clientLocation);
+
         var mgr = new UpdateManager(clientLocation);
         if (!mgr.IsInstalled)
         {
             var message = $"{_options.ApplicationShortName} is not installed.";
+            _logger.LogInformation("Velopack UpdateAsync: {Message}", message);
             OnUpdateInfoEvent(this, message);
             return;
         }
@@ -27,7 +33,10 @@ internal class VelopackApplicationUpdateStateService : ApplicationUpdateStateSer
         var newVersion = await mgr.CheckForUpdatesAsync();
         if (newVersion == null)
         {
+            _logger.LogInformation("Velopack UpdateAsync: already up to date.");
             OnUpdateInfoEvent(this, "Already up to date.");
+            // Make sure no progress bar is shown when there is nothing to download.
+            _splash?.HideProgress();
             return;
         }
 
@@ -46,11 +55,30 @@ internal class VelopackApplicationUpdateStateService : ApplicationUpdateStateSer
             msg = $"version {newVersion.TargetFullRelease.Version} (full)";
         }
 
-        OnUpdateInfoEvent(this, $"Downloading {msg}.");
-        await mgr.DownloadUpdatesAsync(newVersion);
+        _logger.LogInformation("Velopack UpdateAsync: update available - {Msg}.", msg);
 
-        OnUpdateInfoEvent(this, "Installing.");
-        ApplicationBase.ReleaseSingleInstanceLock();
-        mgr.ApplyUpdatesAndRestart(newVersion);
+        // Now we know there is a real download about to happen — show progress bar.
+        _splash?.ShowProgress();
+        if (!_persistentCloseButton)
+        {
+            // During an actual update, hide the close button so the user can't kill it
+            // mid-download. If the splash was opened from the About menu (persistent),
+            // leave the close button visible per the user's intent.
+            _splash?.HideCloseButton();
+        }
+
+        OnUpdateInfoEvent(this, $"Downloading {msg}.");
+        try
+        {
+            await mgr.DownloadUpdatesAsync(newVersion);
+
+            OnUpdateInfoEvent(this, "Installing.");
+            ApplicationBase.ReleaseSingleInstanceLock();
+            mgr.ApplyUpdatesAndRestart(newVersion);
+        }
+        finally
+        {
+            _splash?.HideProgress();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **Persistent close button**: Splash opened with \`showCloseButton: true\` (e.g. About menu) keeps close button visible during update — no longer hidden by \`ShowProgress\`
- **Scoped progress visibility**: Squirrel/Velopack subclasses now control progress/close-button visibility based on whether a download is actually happening — no progress bar shown when "already up to date"
- **try/finally on update**: Always hide progress when download/install completes or fails
- **Defensive Dispatcher check**: Splash creation handles null \`Application.Current.Dispatcher\` gracefully with logging
- **Splash logging**: Structured logging across all splash window actions and update service flow
- **UI**: Hide ExeLocation TextBlock from splash by default

## Test plan
- [ ] Open splash from About — close button visible throughout
- [ ] Trigger update — progress bar appears, close button hidden (unless persistent)
- [ ] "Already up to date" path — no progress bar shown
- [ ] Update failure — progress bar hidden in finally
- [ ] All 146 tests pass