### PR TITLE
feat!: drop net8.0/net9.0 and bump dependencies (→ 2.3.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '2.2'
+  MAJOR_MINOR: '2.3'
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,37 +28,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build -c Release --no-restore 2>&1 | tee build.log
-
-      - name: Check warnings
-        shell: bash
-        run: |
-          WARNING_COUNT=$(grep -c " warning " build.log || true)
-          echo "Build warnings: $WARNING_COUNT"
-          if [ "$WARNING_COUNT" -gt 25 ]; then
-            echo "::error::Build has $WARNING_COUNT warnings (threshold: 25)"
-            exit 1
-          fi
-
-      - name: Test with coverage
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          directory: ./coverage
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
+      # Version is computed BEFORE the build so it can be passed as -p:Version.
+      # Passing it only to `dotnet pack` sets PackageVersion alone, leaving
+      # AssemblyVersion and FileVersion at their default 1.0.0.0 inside the
+      # shipped assembly.
       - name: Compute version
         id: version
         shell: bash
@@ -100,19 +75,52 @@ jobs:
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed pre-release version: $PRE_VERSION"
 
-      - name: Pack (stable)
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      # Pull requests build the pre-release version, pushes to master the
+      # stable one. One value drives build and pack so the assembly and the
+      # package can never disagree.
+      - name: Resolve build version
+        id: buildversion
         shell: bash
         run: |
-          dotnet pack Tharga.Wpf/Tharga.Wpf.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.License/Tharga.License.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION="${{ steps.preversion.outputs.version }}"
+          else
+            VERSION="${{ steps.version.outputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building as: $VERSION"
 
-      - name: Pack (prerelease)
-        if: github.event_name == 'pull_request'
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore -p:Version=${{ steps.buildversion.outputs.version }} 2>&1 | tee build.log
+
+      - name: Check warnings
         shell: bash
         run: |
-          dotnet pack Tharga.Wpf/Tharga.Wpf.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
-          dotnet pack Tharga.License/Tharga.License.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          WARNING_COUNT=$(grep -c " warning " build.log || true)
+          echo "Build warnings: $WARNING_COUNT"
+          if [ "$WARNING_COUNT" -gt 25 ]; then
+            echo "::error::Build has $WARNING_COUNT warnings (threshold: 25)"
+            exit 1
+          fi
+
+      - name: Test with coverage
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Pack
+        shell: bash
+        run: |
+          dotnet pack Tharga.Wpf/Tharga.Wpf.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.License/Tharga.License.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -134,10 +142,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Build for CodeQL
         run: dotnet build -c Release
@@ -296,10 +301,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Install DocFX
         run: dotnet tool install -g docfx

--- a/Tharga.License/Tharga.License.csproj
+++ b/Tharga.License/Tharga.License.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0;</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>1.0.0</Version>
     <Authors>Daniel Bohlin</Authors>

--- a/Tharga.License/Tharga.License.csproj
+++ b/Tharga.License/Tharga.License.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.License/Tharga.License.csproj
+++ b/Tharga.License/Tharga.License.csproj
@@ -21,7 +21,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>1701;1702;CS0809</NoWarn>
+    <!--
+      NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+      Suppressed deliberately. Tharga packages reference their icon from
+      https://thargelion.net/assets/ so all package icons are maintained in one
+      place and can be updated without republishing a package.
+    -->
+    <NoWarn>1701;1702;CS0809;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tharga.License/Tharga.License.csproj
+++ b/Tharga.License/Tharga.License.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.0</Version>
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga License</Product>

--- a/Tharga.Wpf.sln
+++ b/Tharga.Wpf.sln
@@ -6,8 +6,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{56A486D0-5EF5-47EF-8796-08C8F0577A5D}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
-		azure-pipelines.yml = azure-pipelines.yml
-		buildnumber.yml = buildnumber.yml
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/Tharga.Wpf.sln
+++ b/Tharga.Wpf.sln
@@ -5,8 +5,10 @@ VisualStudioVersion = 18.2.11415.280
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{56A486D0-5EF5-47EF-8796-08C8F0577A5D}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		azure-pipelines.yml = azure-pipelines.yml
 		buildnumber.yml = buildnumber.yml
+		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Tharga.Wpf/Features/Dialog/DialogClosePanel.xaml
+++ b/Tharga.Wpf/Features/Dialog/DialogClosePanel.xaml
@@ -6,7 +6,10 @@
              mc:Ignorable="d"
              d:DesignHeight="40" d:DesignWidth="800">
     <Grid>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="1" Margin="5">
+        <!-- The Grid declares no RowDefinitions, so Grid.Row="1" pointed outside
+             the grid; WPF clamped it back to row 0. Dropped, since it never had
+             any effect. -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="5">
             <Button Content="OK" Width="80" IsDefault="True" Command="{Binding OkCommand}" />
             <Button Content="Cancel" Width="80" IsCancel="True" Command="{Binding CancelCommand}" Margin="5,0,0,0" />
         </StackPanel>

--- a/Tharga.Wpf/Framework/SingleInstanceService.cs
+++ b/Tharga.Wpf/Framework/SingleInstanceService.cs
@@ -40,7 +40,11 @@ internal class SingleInstanceService : IDisposable
         {
             using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.Out);
             client.Connect(timeout: 2000);
-            using var writer = new StreamWriter(client) { AutoFlush = true };
+            // Assigned after the using declaration rather than in an object
+            // initializer, so the writer is tracked for disposal from the moment
+            // it is constructed.
+            using var writer = new StreamWriter(client);
+            writer.AutoFlush = true;
             writer.WriteLine(ShowCommand);
         }
         catch

--- a/Tharga.Wpf/Tharga.Wpf.csproj
+++ b/Tharga.Wpf/Tharga.Wpf.csproj
@@ -75,11 +75,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fluent.Ribbon" Version="11.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="System.Management" Version="10.0.8" />
-    <PackageReference Include="Tharga.Runtime" Version="0.1.14" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="System.Management" Version="10.0.10" />
+    <PackageReference Include="Tharga.Runtime" Version="0.1.15" />
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Tharga.Wpf/Tharga.Wpf.csproj
+++ b/Tharga.Wpf/Tharga.Wpf.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.0.0</Version>
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga WPF</Product>

--- a/Tharga.Wpf/Tharga.Wpf.csproj
+++ b/Tharga.Wpf/Tharga.Wpf.csproj
@@ -20,7 +20,13 @@
     <EnableSourceLink>true</EnableSourceLink>
   </PropertyGroup>
   <PropertyGroup>
-    <NoWarn>1701;1702;CS0809</NoWarn>
+    <!--
+      NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+      Suppressed deliberately. Tharga packages reference their icon from
+      https://thargelion.net/assets/ so all package icons are maintained in one
+      place and can be updated without republishing a package.
+    -->
+    <NoWarn>1701;1702;CS0809;NU5048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Images\Application\blue.png" />
@@ -78,7 +84,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
     <PackageReference Include="System.Management" Version="10.0.10" />
-    <PackageReference Include="Tharga.Runtime" Version="0.1.15" />
+    <PackageReference Include="Tharga.Runtime" Version="1.0.0" />
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Patch-level external bumps plus internal `Tharga.*` bumps to consume the tier-0 releases.

External (patch):
- Microsoft.Extensions.DependencyInjection 10.0.8 -> 10.0.10
- Microsoft.Extensions.Hosting 10.0.8 -> 10.0.10 (x2)
- Microsoft.Extensions.Http 10.0.8 -> 10.0.10
- System.Management 10.0.8 -> 10.0.10
- Microsoft.SourceLink.GitHub 10.0.300 -> 10.0.301

Internal:
- Tharga.Runtime 0.1.14 -> 0.1.15

Verified locally: `dotnet test -c Release` passes.