### PR TITLE
fix(pack): publish symbols as snupkg so they actually reach nuget.org

### DIFF
--- a/Tharga.License/Tharga.License.csproj
+++ b/Tharga.License/Tharga.License.csproj
@@ -12,6 +12,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Tharga/Wpf</PackageProjectUrl>
     <IncludeSymbols>true</IncludeSymbols>
+    <!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+         in .nupkg, so the release push loop uploads it as a regular package and
+         nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>true</IncludeSource>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Tharga.Wpf/Tharga.Wpf.csproj
+++ b/Tharga.Wpf/Tharga.Wpf.csproj
@@ -12,6 +12,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Tharga/Wpf</PackageProjectUrl>
     <IncludeSymbols>true</IncludeSymbols>
+    <!-- Without this, pack emits the legacy .symbols.nupkg, whose name still ends
+         in .nupkg, so the release push loop uploads it as a regular package and
+         nuget.org rejects it as a duplicate. No symbols ever shipped. -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>true</IncludeSource>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
`IncludeSymbols` was on but `SymbolPackageFormat` was not set, so pack emitted the legacy `Foo.<version>.symbols.nupkg`.

That filename **still ends in `.nupkg`**, so the release workflow’s

```
for pkg in ./artifacts/*.nupkg; do
  dotnet nuget push "$pkg" ... --skip-duplicate || true
done
```

matched it and pushed it as a *regular* package. nuget.org rejected it as a duplicate of the main package (same id, same version), and the trailing `|| true` swallowed the error — so every release reported success while publishing no symbols at all.

Setting `<SymbolPackageFormat>snupkg</SymbolPackageFormat>` fixes it: a `.snupkg` is not matched by that glob, and `dotnet nuget push` uploads it alongside its `.nupkg` automatically. The artifact step already uploads the whole `./artifacts` directory, so the file survives the hand-off from the build job to the release job.

Verified locally: `dotnet pack -p:Version=9.9.9` now produces both a `.nupkg` and a `.snupkg`.

**No republish is needed** — this takes effect on the next release.